### PR TITLE
Normalize DynamoDB product numeric types

### DIFF
--- a/api/orders.py
+++ b/api/orders.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+from api.schemas.orders import Order, OrderCreate, OrderUpdate
+from services.order_service import OrderService
+from di import get_order_service
+from auth import PermissionChecker
+
+router = APIRouter(prefix="/orders", tags=["orders"])
+
+@router.get("", response_model=List[Order], dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
+async def list_orders(svc: OrderService = Depends(get_order_service)):
+    return svc.list_orders()
+
+@router.get("/{order_id}", response_model=Order, dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
+async def get_order(order_id: str, svc: OrderService = Depends(get_order_service)):
+    order = svc.get_order(order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return order
+
+@router.post("", response_model=Order, dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
+async def create_order(payload: OrderCreate, svc: OrderService = Depends(get_order_service)):
+    return svc.create_order(payload)
+
+@router.put("/{order_id}", response_model=Order, dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def update_order(order_id: str, payload: OrderUpdate, svc: OrderService = Depends(get_order_service)):
+    order = svc.update_order(order_id, payload)
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return order
+
+@router.delete("/{order_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def delete_order(order_id: str, svc: OrderService = Depends(get_order_service)):
+    success = svc.delete_order(order_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return {"message": "Order deleted"}

--- a/api/products.py
+++ b/api/products.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.schemas.products import PutProduct
+from auth import PermissionChecker
+from di import get_product_service
+from services.product_service import ProductService
+
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+@router.get("", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
+async def list_products(
+    category: str | None = None,
+    inventory_type: str | None = None,
+    publish: str | None = None,
+    svc: ProductService = Depends(get_product_service),
+):
+    return svc.list_products(category=category, inventory_type=inventory_type, publish=publish)
+
+
+@router.post("", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def create_product(put_product: PutProduct, svc: ProductService = Depends(get_product_service)):
+    return svc.create(put_product)
+
+
+@router.get("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
+async def get_product(product_id: str, svc: ProductService = Depends(get_product_service)):
+    item = svc.get(product_id)
+    if not item:
+        raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
+    return item
+
+
+@router.put("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def update_product(product_id: str, put_product: PutProduct, svc: ProductService = Depends(get_product_service)):
+    item = svc.update(product_id, put_product)
+    if not item:
+        raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
+    return item
+
+
+@router.delete("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def delete_product(product_id: str, svc: ProductService = Depends(get_product_service)):
+    existing = svc.get(product_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
+    svc.delete(product_id)
+    return {"deleted_product_id": product_id}

--- a/api/products.py
+++ b/api/products.py
@@ -1,56 +1,111 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from typing import Any
+from fastapi import APIRouter, Depends, HTTPException, Query, status, Body
 
-from api.schemas.products import PutProduct
+from api.schemas.products import ProductCreate, ProductOut, ProductUpdate
+from api.schemas.files import FileSpec
 from auth import PermissionChecker
 from di import get_product_service
 from services.product_service import ProductService
 
 
-router = APIRouter(prefix="/products", tags=["products"])
 search_router = APIRouter(prefix="/products_search", tags=["products"])
+router = APIRouter(prefix="/products", tags=["products"])
 
+
+@search_router.get("", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
+async def search_products(
+    q: str | None = Query(None),
+    category: str | None = Query(None),
+    genders: list[str] = Query(default=[]),
+    colors: list[str] = Query(default=[]),
+    minPrice: float | None = Query(None, ge=0),
+    maxPrice: float | None = Query(None, ge=0),
+    minRating: float | None = Query(None, ge=0, le=5),
+    sortBy: str | None = Query(None, regex="^(featured|newest|priceDesc|priceAsc)$"),
+    limit: int = Query(20, ge=1, le=100),
+    nextToken: dict[str, Any] | None = None,
+    svc: ProductService = Depends(get_product_service),
+):
+    filters = {
+        "category": category,
+        "genders": genders,
+        "colors": colors,
+        "min_price": minPrice,
+        "max_price": maxPrice,
+        "min_rating": minRating,
+    }
+    result = svc.search_products(q, filters, sortBy, limit, nextToken)
+    return result
+    #return get_fake_response()
 
 @router.get("", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
-async def list_products(
-    category: str | None = None,
-    inventory_type: str | None = None,
-    publish: str | None = None
-):
-    return get_fake_response()
-    # return svc.list_products(category=category, inventory_type=inventory_type, publish=publish)
+async def list_products(svc: ProductService = Depends(get_product_service)):
+    return svc.list_products()
 
-
-@router.post("", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
-async def create_product(put_product: PutProduct, svc: ProductService = Depends(get_product_service)):
-    return svc.create(put_product)
+@router.post("", response_model=ProductOut, dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def create_product(payload: ProductCreate, svc: ProductService = Depends(get_product_service)):
+    product = svc.create_product(payload)
+    return product
 
 
 @router.get("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
-async def get_product(product_id: str):
+async def get_product(product_id: str, svc: ProductService = Depends(get_product_service)):
+    p = svc.get_product(product_id)
+    if not p:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return p
     print("Getting product:", product_id)
-    return get_fake_product()
-
-@search_router.get("", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
-async def search_products(query: str = Query(..., min_length=1)):
-    return get_fake_search_response()
-    # return svc.search_products(query=query)
-
+    # return get_fake_product()
 
 @router.put("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
-async def update_product(product_id: str, put_product: PutProduct, svc: ProductService = Depends(get_product_service)):
-    item = svc.update(product_id, put_product)
+async def update_product(product_id: str, payload: ProductUpdate, svc: ProductService = Depends(get_product_service)):
+    item = svc.update_product(product_id, payload)
     if not item:
-        raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
+        raise HTTPException(status_code=404, detail="Product not found or not updated")
     return item
 
 
 @router.delete("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
 async def delete_product(product_id: str, svc: ProductService = Depends(get_product_service)):
-    existing = svc.get(product_id)
+    existing = svc.delete_product(product_id)
     if not existing:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return
+
+@router.post("/{product_id}/generate-presigned-urls", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def generate_product_presigned_urls(
+    product_id: str,
+    files: list[FileSpec] = Body(..., embed=False),
+    svc: ProductService = Depends(get_product_service)
+):
+    """Generate presigned URLs for uploading product images to S3"""
+    product = svc.get_product(product_id)
+    if not product:
         raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
-    svc.delete(product_id)
-    return {"deleted_product_id": product_id}
+    
+    try:
+        result = svc.generate_put_presigned_urls(product_id=product_id, files=files)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Error generating presigned URLs: {str(e)}")
+    
+    return {"urls": result}
+
+@router.post("/{product_id}/add_images", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
+async def add_product_images(
+    product_id: str,
+    file_names: list[str] = Body(..., embed=False),
+    svc: ProductService = Depends(get_product_service)
+):
+    """Add image keys to product after successful upload to S3"""
+    try:
+        added_images = svc.add_images(product_id, file_names)
+        return {"added_images": added_images}
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Error adding images: {str(e)}")
+
+
 
 def get_fake_search_response():
     return {

--- a/api/products.py
+++ b/api/products.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.schemas.products import PutProduct
 from auth import PermissionChecker
@@ -7,16 +7,17 @@ from services.product_service import ProductService
 
 
 router = APIRouter(prefix="/products", tags=["products"])
+search_router = APIRouter(prefix="/products_search", tags=["products"])
 
 
 @router.get("", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
 async def list_products(
     category: str | None = None,
     inventory_type: str | None = None,
-    publish: str | None = None,
-    svc: ProductService = Depends(get_product_service),
+    publish: str | None = None
 ):
-    return svc.list_products(category=category, inventory_type=inventory_type, publish=publish)
+    return get_fake_response()
+    # return svc.list_products(category=category, inventory_type=inventory_type, publish=publish)
 
 
 @router.post("", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
@@ -25,11 +26,14 @@ async def create_product(put_product: PutProduct, svc: ProductService = Depends(
 
 
 @router.get("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
-async def get_product(product_id: str, svc: ProductService = Depends(get_product_service)):
-    item = svc.get(product_id)
-    if not item:
-        raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
-    return item
+async def get_product(product_id: str):
+    print("Getting product:", product_id)
+    return get_fake_product()
+
+@search_router.get("", dependencies=[Depends(PermissionChecker(required_permissions=["admin", "user"]))])
+async def search_products(query: str = Query(..., min_length=1)):
+    return get_fake_search_response()
+    # return svc.search_products(query=query)
 
 
 @router.put("/{product_id}", dependencies=[Depends(PermissionChecker(required_permissions=["admin"]))])
@@ -47,3 +51,4283 @@ async def delete_product(product_id: str, svc: ProductService = Depends(get_prod
         raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
     svc.delete(product_id)
     return {"deleted_product_id": product_id}
+
+def get_fake_search_response():
+    return {
+        "results": [
+            {
+                "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b13",
+                "gender": [
+                    "Kids"
+                ],
+                "images": [
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                    "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                ],
+                "reviews": [
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                        "name": "Jayvion Simon",
+                        "postedAt": "2025-11-06T11:43:21+00:00",
+                        "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                        "isPurchased": True,
+                        "rating": 4.2,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                        "helpful": 9911,
+                        "attachments": []
+                    },
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                        "name": "Lucian Obrien",
+                        "postedAt": "2025-11-05T10:43:21+00:00",
+                        "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                        "isPurchased": True,
+                        "rating": 3.7,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                        "helpful": 1947,
+                        "attachments": [
+                            "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                        ]
+                    },
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                        "name": "Deja Brady",
+                        "postedAt": "2025-11-04T09:43:21+00:00",
+                        "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                        "isPurchased": True,
+                        "rating": 4.5,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                        "helpful": 9124,
+                        "attachments": []
+                    },
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                        "name": "Harrison Stein",
+                        "postedAt": "2025-11-03T08:43:21+00:00",
+                        "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                        "isPurchased": False,
+                        "rating": 3.5,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                        "helpful": 6984,
+                        "attachments": [
+                            "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                            "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                        ]
+                    },
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                        "name": "Reece Chung",
+                        "postedAt": "2025-11-02T07:43:21+00:00",
+                        "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                        "isPurchased": False,
+                        "rating": 0.5,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                        "helpful": 8488,
+                        "attachments": []
+                    },
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                        "name": "Lainey Davidson",
+                        "postedAt": "2025-11-01T06:43:21+00:00",
+                        "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                        "isPurchased": True,
+                        "rating": 3,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                        "helpful": 2034,
+                        "attachments": [
+                            "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                            "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                            "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                        ]
+                    },
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                        "name": "Cristopher Cardenas",
+                        "postedAt": "2025-10-31T05:43:21+00:00",
+                        "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                        "isPurchased": False,
+                        "rating": 2.5,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                        "helpful": 3364,
+                        "attachments": []
+                    },
+                    {
+                        "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                        "name": "Melanie Noble",
+                        "postedAt": "2025-10-30T04:43:21+00:00",
+                        "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                        "isPurchased": False,
+                        "rating": 2.8,
+                        "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                        "helpful": 8401,
+                        "attachments": []
+                    }
+                ],
+                "publish": "draft",
+                "ratings": [
+                    {
+                        "name": "1 Star",
+                        "starCount": 9911,
+                        "reviewCount": 1947
+                    },
+                    {
+                        "name": "2 Star",
+                        "starCount": 1947,
+                        "reviewCount": 9124
+                    },
+                    {
+                        "name": "3 Star",
+                        "starCount": 9124,
+                        "reviewCount": 6984
+                    },
+                    {
+                        "name": "4 Star",
+                        "starCount": 6984,
+                        "reviewCount": 8488
+                    },
+                    {
+                        "name": "5 Star",
+                        "starCount": 8488,
+                        "reviewCount": 2034
+                    }
+                ],
+                "category": "Accessories",
+                "available": 0,
+                "priceSale": 64.55,
+                "taxes": 10,
+                "quantity": 80,
+                "inventoryType": "out of stock",
+                "tags": [
+                    "Technology",
+                    "Health and Wellness",
+                    "Travel",
+                    "Finance",
+                    "Education"
+                ],
+                "code": "38BEE2712",
+                "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+                "sku": "WW75K52112YW/SV",
+                "createdAt": "2025-10-24T23:43:21+00:00",
+                "name": "Beach Sandals",
+                "price": 64.55,
+                "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-13.webp",
+                "colors": [
+                    "#FFC0CB",
+                    "#00AB55",
+                    "#FFC107",
+                    "#7F00FF",
+                    "#000000"
+                ],
+                "totalRatings": 3.9,
+                "totalSold": 839,
+                "totalReviews": 3035,
+                "newLabel": {
+                    "enabled": False,
+                    "content": "NEW"
+                },
+                "saleLabel": {
+                    "enabled": False,
+                    "content": "SALE"
+                },
+                "sizes": [
+                    "6",
+                    "7",
+                    "8",
+                    "8.5",
+                    "9",
+                    "9.5",
+                    "10",
+                    "10.5",
+                    "11",
+                    "11.5",
+                    "12",
+                    "13"
+                ],
+                "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+            }
+        ]
+    }
+
+def get_fake_product():
+    return {
+        "product": {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2025-11-06T11:11:34+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2025-11-05T10:11:34+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2025-11-04T09:11:34+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2025-11-03T08:11:34+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2025-11-02T07:11:34+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2025-11-01T06:11:34+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2025-10-31T05:11:34+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2025-10-30T04:11:34+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE275",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5215YW/SV",
+            "createdAt": "2025-11-01T06:11:34+00:00",
+            "name": "Chic Ballet Flats",
+            "price": 25.18,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+            "colors": [
+                "#7F00FF",
+                "#FFC107"
+            ],
+            "totalRatings": 3,
+            "totalSold": 951,
+            "totalReviews": 3364,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": True,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        }
+}
+
+def get_fake_response():
+    return {
+    "products": [
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+            "gender": [
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "draft",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Accessories",
+            "available": 0,
+            "priceSale": 83.74,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "out of stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE270",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5210YW/SV",
+            "createdAt": "2024-08-19T18:58:39+00:00",
+            "name": "Urban Explorer Sneakers",
+            "price": 83.74,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+            "colors": [
+                "#FF4842",
+                "#1890FF"
+            ],
+            "totalRatings": 4.2,
+            "totalSold": 763,
+            "totalReviews": 1947,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE271",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5211YW/SV",
+            "createdAt": "2024-08-18T17:58:39+00:00",
+            "name": "Classic Leather Loafers",
+            "price": 97.14,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+            "colors": [
+                "#1890FF",
+                "#FFC0CB"
+            ],
+            "totalRatings": 3.7,
+            "totalSold": 684,
+            "totalReviews": 9124,
+            "newLabel": {
+                "enabled": True,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+            "gender": [
+                "Women",
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Apparel",
+            "available": 10,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "low stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE272",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5212YW/SV",
+            "createdAt": "2024-08-17T16:58:39+00:00",
+            "name": "Mountain Trekking Boots",
+            "price": 68.71,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+            "colors": [
+                "#FFC0CB",
+                "#00AB55"
+            ],
+            "totalRatings": 4.5,
+            "totalSold": 451,
+            "totalReviews": 6984,
+            "newLabel": {
+                "enabled": True,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "draft",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": 85.21,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE273",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5213YW/SV",
+            "createdAt": "2024-08-16T15:58:39+00:00",
+            "name": "Elegance Stiletto Heels",
+            "price": 85.21,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+            "colors": [
+                "#00AB55",
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 3.5,
+            "totalSold": 433,
+            "totalReviews": 8488,
+            "newLabel": {
+                "enabled": True,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+            "gender": [
+                "Women",
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Apparel",
+            "available": 10,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "low stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE274",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5214YW/SV",
+            "createdAt": "2024-08-15T14:58:39+00:00",
+            "name": "Comfy Running Shoes",
+            "price": 52.17,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+            "colors": [
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 0.5,
+            "totalSold": 463,
+            "totalReviews": 2034,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": True,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE275",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5215YW/SV",
+            "createdAt": "2024-08-14T13:58:39+00:00",
+            "name": "Chic Ballet Flats",
+            "price": 25.18,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+            "colors": [
+                "#7F00FF"
+            ],
+            "totalRatings": 3,
+            "totalSold": 951,
+            "totalReviews": 3364,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": True,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+            "gender": [
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "draft",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Accessories",
+            "available": 0,
+            "priceSale": 43.84,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "out of stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE276",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5216YW/SV",
+            "createdAt": "2024-08-13T12:58:39+00:00",
+            "name": "Vintage Oxford Shoes",
+            "price": 43.84,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+            "colors": [
+                "#FF4842",
+                "#1890FF"
+            ],
+            "totalRatings": 2.5,
+            "totalSold": 194,
+            "totalReviews": 8401,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE277",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5217YW/SV",
+            "createdAt": "2024-08-12T11:58:39+00:00",
+            "name": "Waterproof Hiking Boots",
+            "price": 60.98,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp",
+            "colors": [
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 2.8,
+            "totalSold": 425,
+            "totalReviews": 8996,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b9",
+            "gender": [
+                "Women",
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Apparel",
+            "available": 10,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "low stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE278",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5218YW/SV",
+            "createdAt": "2024-08-11T10:58:39+00:00",
+            "name": "Casual Slip-On Sneakers",
+            "price": 98.42,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-9.webp",
+            "colors": [
+                "#FFC0CB",
+                "#00AB55"
+            ],
+            "totalRatings": 4.9,
+            "totalSold": 435,
+            "totalReviews": 5271,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b10",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "draft",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": 53.37,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE279",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K5219YW/SV",
+            "createdAt": "2024-08-10T09:58:39+00:00",
+            "name": "Premium Dress Shoes",
+            "price": 53.37,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-10.webp",
+            "colors": [
+                "#FFC0CB",
+                "#00AB55",
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 3.6,
+            "totalSold": 807,
+            "totalReviews": 8478,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b11",
+            "gender": [
+                "Women",
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Apparel",
+            "available": 10,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "low stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2710",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52110YW/SV",
+            "createdAt": "2024-08-09T08:58:39+00:00",
+            "name": "Sporty Trail Runners",
+            "price": 72.75,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-11.webp",
+            "colors": [
+                "#00AB55",
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 2.5,
+            "totalSold": 521,
+            "totalReviews": 1139,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b12",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2711",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52111YW/SV",
+            "createdAt": "2024-08-08T07:58:39+00:00",
+            "name": "Sophisticated Brogues",
+            "price": 56.61,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-12.webp",
+            "colors": [
+                "#FFC0CB",
+                "#00AB55",
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 1.7,
+            "totalSold": 538,
+            "totalReviews": 8061,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b13",
+            "gender": [
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "draft",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Accessories",
+            "available": 0,
+            "priceSale": 64.55,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "out of stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2712",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52112YW/SV",
+            "createdAt": "2024-08-07T06:58:39+00:00",
+            "name": "Beach Sandals",
+            "price": 64.55,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-13.webp",
+            "colors": [
+                "#FFC0CB",
+                "#00AB55",
+                "#FFC107",
+                "#7F00FF",
+                "#000000"
+            ],
+            "totalRatings": 3.9,
+            "totalSold": 839,
+            "totalReviews": 3035,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b14",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2713",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52113YW/SV",
+            "createdAt": "2024-08-06T05:58:39+00:00",
+            "name": "Stylish Wedge Heels",
+            "price": 77.32,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-14.webp",
+            "colors": [
+                "#FFC107",
+                "#7F00FF",
+                "#000000"
+            ],
+            "totalRatings": 2.8,
+            "totalSold": 394,
+            "totalReviews": 6733,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b15",
+            "gender": [
+                "Women",
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Apparel",
+            "available": 10,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "low stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2714",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52114YW/SV",
+            "createdAt": "2024-08-05T04:58:39+00:00",
+            "name": "Lightweight Training Shoes",
+            "price": 60.62,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-15.webp",
+            "colors": [
+                "#FF4842",
+                "#1890FF"
+            ],
+            "totalRatings": 4.1,
+            "totalSold": 269,
+            "totalReviews": 3952,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b16",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "draft",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": 79.81,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2715",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52115YW/SV",
+            "createdAt": "2024-08-04T03:58:39+00:00",
+            "name": "Luxurious Moccasins",
+            "price": 79.81,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-16.webp",
+            "colors": [
+                "#7F00FF",
+                "#000000",
+                "#FFFFFF"
+            ],
+            "totalRatings": 4.5,
+            "totalSold": 453,
+            "totalReviews": 2405,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b17",
+            "gender": [
+                "Women",
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Apparel",
+            "available": 10,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "low stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2716",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52116YW/SV",
+            "createdAt": "2024-08-03T02:58:39+00:00",
+            "name": "Durable Work Boots",
+            "price": 93.68,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-17.webp",
+            "colors": [
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 2.2,
+            "totalSold": 821,
+            "totalReviews": 3127,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b18",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2717",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52117YW/SV",
+            "createdAt": "2024-08-02T01:58:39+00:00",
+            "name": "Trendy Platform Sneakers",
+            "price": 47.44,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-18.webp",
+            "colors": [
+                "#7F00FF"
+            ],
+            "totalRatings": 3.2,
+            "totalSold": 364,
+            "totalReviews": 6843,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b19",
+            "gender": [
+                "Kids"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "draft",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Accessories",
+            "available": 0,
+            "priceSale": 76.24,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "out of stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2718",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52118YW/SV",
+            "createdAt": "2024-08-01T00:58:39+00:00",
+            "name": "Cozy Winter Boots",
+            "price": 76.24,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-19.webp",
+            "colors": [
+                "#FF4842",
+                "#1890FF"
+            ],
+            "totalRatings": 0.6,
+            "totalSold": 849,
+            "totalReviews": 4672,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        },
+        {
+            "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b20",
+            "gender": [
+                "Men"
+            ],
+            "images": [
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-2.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-5.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+            ],
+            "reviews": [
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b1",
+                    "name": "Jayvion Simon",
+                    "postedAt": "2024-08-19T18:58:39+00:00",
+                    "comment": "The sun slowly set over the horizon, painting the sky in vibrant hues of orange and pink.",
+                    "isPurchased": True,
+                    "rating": 4.2,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-1.webp",
+                    "helpful": 9911,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b2",
+                    "name": "Lucian Obrien",
+                    "postedAt": "2024-08-18T17:58:39+00:00",
+                    "comment": "She eagerly opened the gift, her eyes sparkling with excitement.",
+                    "isPurchased": True,
+                    "rating": 3.7,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-2.webp",
+                    "helpful": 1947,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-1.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b3",
+                    "name": "Deja Brady",
+                    "postedAt": "2024-08-17T16:58:39+00:00",
+                    "comment": "The old oak tree stood tall and majestic, its branches swaying gently in the breeze.",
+                    "isPurchased": True,
+                    "rating": 4.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-3.webp",
+                    "helpful": 9124,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b4",
+                    "name": "Harrison Stein",
+                    "postedAt": "2024-08-16T15:58:39+00:00",
+                    "comment": "The aroma of freshly brewed coffee filled the air, awakening my senses.",
+                    "isPurchased": False,
+                    "rating": 3.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-4.webp",
+                    "helpful": 6984,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-3.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-4.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b5",
+                    "name": "Reece Chung",
+                    "postedAt": "2024-08-15T14:58:39+00:00",
+                    "comment": "The children giggled with joy as they ran through the sprinklers on a hot summer day.",
+                    "isPurchased": False,
+                    "rating": 0.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-5.webp",
+                    "helpful": 8488,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b6",
+                    "name": "Lainey Davidson",
+                    "postedAt": "2024-08-14T13:58:39+00:00",
+                    "comment": "He carefully crafted a beautiful sculpture out of clay, his hands skillfully shaping the intricate details.",
+                    "isPurchased": True,
+                    "rating": 3,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-6.webp",
+                    "helpful": 2034,
+                    "attachments": [
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-6.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-7.webp",
+                        "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-8.webp"
+                    ]
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b7",
+                    "name": "Cristopher Cardenas",
+                    "postedAt": "2024-08-13T12:58:39+00:00",
+                    "comment": "The concert was a mesmerizing experience, with the music filling the venue and the crowd cheering in delight.",
+                    "isPurchased": False,
+                    "rating": 2.5,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-7.webp",
+                    "helpful": 3364,
+                    "attachments": []
+                },
+                {
+                    "id": "e99f09a7-dd88-49d5-b1c8-1daf80c2d7b8",
+                    "name": "Melanie Noble",
+                    "postedAt": "2024-08-12T11:58:39+00:00",
+                    "comment": "The waves crashed against the shore, creating a soothing symphony of sound.",
+                    "isPurchased": False,
+                    "rating": 2.8,
+                    "avatarUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/avatar/avatar-8.webp",
+                    "helpful": 8401,
+                    "attachments": []
+                }
+            ],
+            "publish": "published",
+            "ratings": [
+                {
+                    "name": "1 Star",
+                    "starCount": 9911,
+                    "reviewCount": 1947
+                },
+                {
+                    "name": "2 Star",
+                    "starCount": 1947,
+                    "reviewCount": 9124
+                },
+                {
+                    "name": "3 Star",
+                    "starCount": 9124,
+                    "reviewCount": 6984
+                },
+                {
+                    "name": "4 Star",
+                    "starCount": 6984,
+                    "reviewCount": 8488
+                },
+                {
+                    "name": "5 Star",
+                    "starCount": 8488,
+                    "reviewCount": 2034
+                }
+            ],
+            "category": "Shose",
+            "available": 72,
+            "priceSale": None,
+            "taxes": 10,
+            "quantity": 80,
+            "inventoryType": "in stock",
+            "tags": [
+                "Technology",
+                "Health and Wellness",
+                "Travel",
+                "Finance",
+                "Education"
+            ],
+            "code": "38BEE2719",
+            "description": "\n<h6>Specifications</h6>\n<table>\n  <tbody>\n    <tr>\n      <td>Category</td>\n      <td>Mobile</td>\n    </tr>\n    <tr>\n      <td>Manufacturer</td>\n      <td>Apple</td>\n    </tr>\n    <tr>\n      <td>Warranty</td>\n      <td>12 Months</td>\n    </tr>\n    <tr>\n      <td>Serial number</td>\n      <td>358607726380311</td>\n    </tr>\n    <tr>\n      <td>Ships from</td>\n      <td>United States</td>\n    </tr>\n  </tbody>\n</table>\n\n<h6>Product details</h6>\n<ul>\n  <li>\n    <p>The foam sockliner feels soft and comfortable</p>\n  </li>\n  <li>\n    <p>Pull tab</p>\n  </li>\n  <li>\n    <p>Not intended for use as Personal Protective Equipment</p>\n  </li>\n  <li>\n    <p>Colour Shown: White/Black/Oxygen Purple/Action Grape</p>\n  </li>\n  <li>\n    <p>Style: 921826-109</p>\n  </li>\n  <li>\n    <p>Country/Region of Origin: China</p>\n  </li>\n</ul>\n<h6>Benefits</h6>\n<ul>\n  <li>\n    <p>Mesh and synthetic materials on the upper keep the fluid look of the OG while adding comfort</p>\n    and durability.\n  </li>\n  <li>\n    <p>Originally designed for performance running, the full-length Max Air unit adds soft, comfortable cushio</p>\n    ning underfoot.\n  </li>\n  <li>\n    <p>The foam midsole feels springy and soft.</p>\n  </li>\n  <li>\n    <p>The rubber outsole adds traction and durability.</p>\n  </li>\n</ul>\n<h6>Delivery and returns</h6>\n<p>Your order of $200 or more gets free standard delivery.</p>\n<ul>\n  <li>\n    <p>Standard delivered 4-5 Business Days</p>\n  </li>\n  <li>\n    <p>Express delivered 2-4 Business Days</p>\n  </li>\n</ul>\n<p>Orders are processed and delivered Monday-Friday (excluding public holidays)</p>\n\n",
+            "sku": "WW75K52119YW/SV",
+            "createdAt": "2024-07-30T23:58:39+00:00",
+            "name": "Fashion Ankle Boots",
+            "price": 92.87,
+            "coverUrl": "https://api-dev-minimal-v610.pages.dev/assets/images/m-product/product-20.webp",
+            "colors": [
+                "#FFC107",
+                "#7F00FF"
+            ],
+            "totalRatings": 1.3,
+            "totalSold": 804,
+            "totalReviews": 6995,
+            "newLabel": {
+                "enabled": False,
+                "content": "NEW"
+            },
+            "saleLabel": {
+                "enabled": False,
+                "content": "SALE"
+            },
+            "sizes": [
+                "6",
+                "7",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+                "10.5",
+                "11",
+                "11.5",
+                "12",
+                "13"
+            ],
+            "subDescription": "Featuring the original ripple design inspired by Japanese bullet trains, the Nike Air Max 97 lets you push your style full-speed ahead."
+        }
+    ]
+}

--- a/api/schemas/orders.py
+++ b/api/schemas/orders.py
@@ -1,0 +1,82 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from datetime import datetime
+
+class OrderItem(BaseModel):
+    id: str
+    sku: str
+    quantity: int
+    name: str
+    coverUrl: str
+    price: float
+    available: int
+    colors: List[str]
+    size: str
+
+class TimelineItem(BaseModel):
+    title: str
+    time: datetime
+
+class OrderHistory(BaseModel):
+    orderTime: datetime
+    paymentTime: Optional[datetime] = None
+    deliveryTime: Optional[datetime] = None
+    completionTime: Optional[datetime] = None
+    timeline: List[TimelineItem]
+
+class Customer(BaseModel):
+    id: str
+    name: str
+    email: str
+    phoneNumber: str
+    avatarUrl: Optional[str] = None
+    ipAddress: Optional[str] = None
+
+class Delivery(BaseModel):
+    shipment_amount: int
+    delivery_type: str
+
+class ShippingAddress(BaseModel):
+    fullAddress: str
+    addressType: str
+    company: str
+
+class Payment(BaseModel):
+    payment: str
+    cardType: str
+    cardNumber: str
+
+class Order(BaseModel):
+    id: str
+    orderNumber: str
+    createdAt: datetime
+    taxes: float
+    items: List[OrderItem]
+    history: OrderHistory
+    subtotal: float
+    shipping: float
+    discount: float
+    customer: Customer
+    delivery: Delivery
+    totalAmount: float
+    totalQuantity: int
+    shippingAddress: ShippingAddress
+    payment: Payment
+    status: str
+
+class OrderCreate(BaseModel):
+    items: List[OrderItem]
+    subtotal: float
+    shipping: float
+    discount: float
+    customer: Customer
+    delivery: Delivery
+    totalAmount: float
+    totalQuantity: int
+    shippingAddress: ShippingAddress
+    payment: Payment
+
+class OrderUpdate(BaseModel):
+    status: Optional[str] = None
+    delivery: Optional[Delivery] = None
+

--- a/api/schemas/products.py
+++ b/api/schemas/products.py
@@ -1,68 +1,117 @@
-from __future__ import annotations
-
 from typing import List, Optional
+from pydantic import BaseModel, Field
+from datetime import datetime
+from core.casing import camel_alias
 
-from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
+class CamelModel(BaseModel):
+    model_config = {
+        "alias_generator": camel_alias,
+        "populate_by_name": True,
+        "from_attributes": True,
+    }
 
+class Label(CamelModel):
+    enabled: bool
+    content: str
 
-class CamelCaseModel(BaseModel):
-    model_config = ConfigDict(
-        alias_generator=to_camel,
-        populate_by_name=True,
-        extra="allow",
-    )
+class RatingBucket(CamelModel):
+    name: str
+    star_count: int
+    review_count: int
 
-
-class ProductLabel(CamelCaseModel):
-    enabled: Optional[bool] = None
-    content: Optional[str] = None
-
-
-class ProductRating(CamelCaseModel):
-    name: Optional[str] = None
-    star_count: Optional[int] = None
-    review_count: Optional[int] = None
-
-
-class ProductReview(CamelCaseModel):
-    id: Optional[str] = None
-    name: Optional[str] = None
-    posted_at: Optional[str] = None
-    comment: Optional[str] = None
-    is_purchased: Optional[bool] = None
-    rating: Optional[float] = None
+class Review(CamelModel):
+    id: str
+    name: str
+    posted_at: datetime
+    comment: str
+    is_purchased: bool
+    rating: float
     avatar_url: Optional[str] = None
-    helpful: Optional[int] = None
-    attachments: Optional[List[str]] = None
+    helpful: int
+    attachments: List[str] = []
 
-
-class PutProduct(CamelCaseModel):
-    id: Optional[str] = None
-    name: Optional[str] = None
-    gender: Optional[List[str]] = None
-    images: Optional[List[str]] = None
-    reviews: Optional[List[ProductReview]] = None
-    publish: Optional[str] = None
-    ratings: Optional[List[ProductRating]] = None
-    category: Optional[str] = None
-    available: Optional[int] = None
+class ProductOut(CamelModel):
+    id: str
+    gender: List[str]
+    images: List[str]
+    reviews: List[Review]
+    publish: str
+    ratings: List[RatingBucket]
+    category: str
+    available: int
     price_sale: Optional[float] = None
     taxes: Optional[float] = None
-    quantity: Optional[int] = None
+    quantity: int
     inventory_type: Optional[str] = None
-    tags: Optional[List[str]] = None
+    tags: List[str]
     code: Optional[str] = None
     description: Optional[str] = None
     sku: Optional[str] = None
-    created_at: Optional[str] = None
-    price: Optional[float] = None
+    created_at: datetime | str
+    name: str
+    price: float
     cover_url: Optional[str] = None
+    colors: List[str]
+    total_ratings: float
+    total_sold: int
+    total_reviews: int
+    new_label: Label
+    sale_label: Label
+    sizes: List[str]
+    sub_description: Optional[str] = None
+
+class ProductCreate(CamelModel):
+    # Campos mínimos + opcionales; id lo generamos en el backend (UUID)
+    name: str
+    category: str
+    price: float
+    publish: str = "published"
+    available: int = 0
+    quantity: int = 0
+    taxes: Optional[float] = None
+    price_sale: Optional[float] = None
+    inventory_type: Optional[str] = None
+    code: Optional[str] = None
+    sku: Optional[str] = None
+    description: Optional[str] = None  # HTML
+    sub_description: Optional[str] = None
+    cover_url: Optional[str] = None
+    gender: List[str] = []
+    tags: List[str] = []
+    images: Optional[List] = None
+    colors: List[str] = []
+    sizes: List[str] = []
+    ratings: List[RatingBucket] = []
+    reviews: List[Review] = []
+
+class ProductUpdate(CamelModel):
+    # PUT parcial: todos opcionales; solo actualizamos lo presente
+    name: Optional[str] = None
+    category: Optional[str] = None
+    price: Optional[float] = None
+    publish: Optional[str] = None
+    available: Optional[int] = None
+    quantity: Optional[int] = None
+    taxes: Optional[float] = None
+    price_sale: Optional[float] = None
+    inventory_type: Optional[str] = None
+    code: Optional[str] = None
+    sku: Optional[str] = None
+    description: Optional[str] = None
+    sub_description: Optional[str] = None
+    cover_url: Optional[str] = None
+    gender: Optional[List[str]] = None
+    tags: Optional[List[str]] = None
+    images: Optional[List[str]] = None
     colors: Optional[List[str]] = None
+    sizes: Optional[List[str]] = None
+    ratings: Optional[List[RatingBucket]] = None
+    reviews: Optional[List[Review]] = None
     total_ratings: Optional[float] = None
     total_sold: Optional[int] = None
     total_reviews: Optional[int] = None
-    new_label: Optional[ProductLabel] = None
-    sale_label: Optional[ProductLabel] = None
-    sizes: Optional[List[str]] = None
-    sub_description: Optional[str] = None
+
+class ProductListOut(CamelModel):
+    items: List[ProductOut]
+    limit: int
+    next_token: Optional[dict] = Field(default=None, alias="nextToken")

--- a/api/schemas/products.py
+++ b/api/schemas/products.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class CamelCaseModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="allow",
+    )
+
+
+class ProductLabel(CamelCaseModel):
+    enabled: Optional[bool] = None
+    content: Optional[str] = None
+
+
+class ProductRating(CamelCaseModel):
+    name: Optional[str] = None
+    star_count: Optional[int] = None
+    review_count: Optional[int] = None
+
+
+class ProductReview(CamelCaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    posted_at: Optional[str] = None
+    comment: Optional[str] = None
+    is_purchased: Optional[bool] = None
+    rating: Optional[float] = None
+    avatar_url: Optional[str] = None
+    helpful: Optional[int] = None
+    attachments: Optional[List[str]] = None
+
+
+class PutProduct(CamelCaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    gender: Optional[List[str]] = None
+    images: Optional[List[str]] = None
+    reviews: Optional[List[ProductReview]] = None
+    publish: Optional[str] = None
+    ratings: Optional[List[ProductRating]] = None
+    category: Optional[str] = None
+    available: Optional[int] = None
+    price_sale: Optional[float] = None
+    taxes: Optional[float] = None
+    quantity: Optional[int] = None
+    inventory_type: Optional[str] = None
+    tags: Optional[List[str]] = None
+    code: Optional[str] = None
+    description: Optional[str] = None
+    sku: Optional[str] = None
+    created_at: Optional[str] = None
+    price: Optional[float] = None
+    cover_url: Optional[str] = None
+    colors: Optional[List[str]] = None
+    total_ratings: Optional[float] = None
+    total_sold: Optional[int] = None
+    total_reviews: Optional[int] = None
+    new_label: Optional[ProductLabel] = None
+    sale_label: Optional[ProductLabel] = None
+    sizes: Optional[List[str]] = None
+    sub_description: Optional[str] = None

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from api.calendar import router as calendar_router
 from api.scheduled import router as scheduled_router
 from api.workspaces import router as workspaces_router
 from api.friendly_scripts import router as friendly_scripts_router
+from api.products import router as products_router
 from core.error_handlers import install_error_handlers
 from core.logging_config import configure_logging
 from core.request_context import RequestContextMiddleware
@@ -43,6 +44,7 @@ def create_app() -> FastAPI:
     app.include_router(workspaces_router)
     app.include_router(friendly_scripts_router)
     app.include_router(scheduled_router)
+    app.include_router(products_router)
     # locale.setlocale(locale.LC_ALL, 'en_US.utf-8')
     return app
 

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from api.workspaces import router as workspaces_router
 from api.friendly_scripts import router as friendly_scripts_router
 from api.products import router as products_router
 from api.products import search_router as search_product_router
+from api.orders import router as orders_router
 from core.error_handlers import install_error_handlers
 from core.logging_config import configure_logging
 from core.request_context import RequestContextMiddleware
@@ -47,6 +48,7 @@ def create_app() -> FastAPI:
     app.include_router(scheduled_router)
     app.include_router(products_router)
     app.include_router(search_product_router)
+    app.include_router(orders_router)
     # locale.setlocale(locale.LC_ALL, 'en_US.utf-8')
     return app
 

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from api.scheduled import router as scheduled_router
 from api.workspaces import router as workspaces_router
 from api.friendly_scripts import router as friendly_scripts_router
 from api.products import router as products_router
+from api.products import search_router as search_product_router
 from core.error_handlers import install_error_handlers
 from core.logging_config import configure_logging
 from core.request_context import RequestContextMiddleware
@@ -45,6 +46,7 @@ def create_app() -> FastAPI:
     app.include_router(friendly_scripts_router)
     app.include_router(scheduled_router)
     app.include_router(products_router)
+    app.include_router(search_product_router)
     # locale.setlocale(locale.LC_ALL, 'en_US.utf-8')
     return app
 

--- a/core/casing.py
+++ b/core/casing.py
@@ -1,0 +1,9 @@
+import re
+
+def to_camel(s: str) -> str:
+    parts = s.split('_')
+    return parts[0] + ''.join(p.capitalize() for p in parts[1:])
+
+# Para Pydantic v2
+def camel_alias(field_name: str) -> str:
+    return to_camel(field_name)

--- a/di.py
+++ b/di.py
@@ -17,6 +17,8 @@ from repositories.notifications.courier_email_impl import CourierNotificationSen
 from services.workspace_service import WorkspaceService
 from services.product_service import ProductService
 from repositories.product_repo_ddb import ProductRepo
+from services.order_service import OrderService
+from repositories.order_repo_ddb import OrderRepo
 
 
 def get_notification_orchestator() -> Notifications:
@@ -61,4 +63,9 @@ def get_workspace_service() -> WorkspaceService:
 
 def get_product_service() -> ProductService:
     repo = ProductRepo()
-    return ProductService(repo)
+    s3 = S3Adapter()
+    return ProductService(repo, s3)
+
+def get_order_service() -> OrderService:
+    repo = OrderRepo()
+    return OrderService(repo)

--- a/di.py
+++ b/di.py
@@ -15,6 +15,8 @@ from repositories.payment_requests_repo_ddb import PaymentRequestsRepo
 from repositories.notifications.magicbell_impl import MagicBellNotificationSender
 from repositories.notifications.courier_email_impl import CourierNotificationSender
 from services.workspace_service import WorkspaceService
+from services.product_service import ProductService
+from repositories.product_repo_ddb import ProductRepo
 
 
 def get_notification_orchestator() -> Notifications:
@@ -55,3 +57,8 @@ def get_workspace_service() -> WorkspaceService:
     repo = WorkspaceRepo()
     user_svc = get_user_service()
     return WorkspaceService(repo, user_svc=user_svc)
+
+
+def get_product_service() -> ProductService:
+    repo = ProductRepo()
+    return ProductService(repo)

--- a/repositories/ddb_session.py
+++ b/repositories/ddb_session.py
@@ -18,3 +18,6 @@ def tour_table():
 
 def workspace_table():
     return ddb_resource().Table(os.environ.get("WORKSPACE_TABLE_NAME"))
+
+def product_table():
+    return ddb_resource().Table(os.environ.get("PRODUCT_TABLE_NAME"))

--- a/repositories/ddb_session.py
+++ b/repositories/ddb_session.py
@@ -21,3 +21,6 @@ def workspace_table():
 
 def product_table():
     return ddb_resource().Table(os.environ.get("PRODUCT_TABLE_NAME"))
+
+def order_table():
+    return ddb_resource().Table(os.environ.get("ORDER_TABLE_NAME"))

--- a/repositories/order_repo_ddb.py
+++ b/repositories/order_repo_ddb.py
@@ -1,0 +1,98 @@
+import boto3
+import os
+import uuid
+from typing import List, Optional, Dict, Any
+from datetime import datetime, timezone
+from boto3.dynamodb.conditions import Key
+
+from decimal import Decimal
+from .ddb_session import order_table
+
+def to_decimal(value: Any) -> Decimal:
+    """Convierte int/float/str/None a Decimal de forma segura."""
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+class OrderRepo:
+    def __init__(self):
+        self.table = order_table()
+
+    def _now_iso(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def create(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        order_id = str(uuid.uuid4())
+        now = self._now_iso()
+        
+        # Generate a simple order number (in a real app this might be more complex)
+        order_number = f"#{int(datetime.now().timestamp())}"
+
+        # Convert items prices to Decimal
+        items = []
+        for i in payload.get("items", []):
+            item_data = i.model_dump() if hasattr(i, "model_dump") else i
+            if "price" in item_data:
+                item_data["price"] = to_decimal(item_data["price"])
+            items.append(item_data)
+
+        item = {
+            "id": order_id,
+            "orderNumber": order_number,
+            "createdAt": now,
+            "taxes": to_decimal(payload.get("taxes", 0)),
+            "items": items,
+            "history": {
+                "orderTime": now,
+                "timeline": [
+                    {"title": "Order placed", "time": now}
+                ]
+            },
+            "subtotal": to_decimal(payload.get("subtotal", 0)),
+            "shipping": to_decimal(payload.get("shipping", 0)),
+            "discount": to_decimal(payload.get("discount", 0)),
+            "customer": payload.get("customer", {}).model_dump() if hasattr(payload.get("customer"), "model_dump") else payload.get("customer", {}),
+            "delivery": payload.get("delivery", {}).model_dump() if hasattr(payload.get("delivery"), "model_dump") else payload.get("delivery", {}),
+            "totalAmount": to_decimal(payload.get("totalAmount", 0)),
+            "totalQuantity": payload.get("totalQuantity", 0),
+            "shippingAddress": payload.get("shippingAddress", {}).model_dump() if hasattr(payload.get("shippingAddress"), "model_dump") else payload.get("shippingAddress", {}),
+            "payment": payload.get("payment", {}).model_dump() if hasattr(payload.get("payment"), "model_dump") else payload.get("payment", {}),
+            "status": "pending"
+        }
+        
+        self.table.put_item(Item=item)
+        return item
+
+    def list_all(self) -> List[Dict[str, Any]]:
+        # In a real scenario, we would handle pagination and scanning properly
+        response = self.table.scan()
+        return response.get("Items", [])
+
+    def get_by_id(self, order_id: str) -> Optional[Dict[str, Any]]:
+        response = self.table.get_item(Key={"id": order_id})
+        return response.get("Item")
+
+    def update(self, order_id: str, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        # Simple update implementation
+        current = self.get_by_id(order_id)
+        if not current:
+            return None
+            
+        # Merge payload into current
+        # Note: This is a simplified update. For production, use UpdateExpression
+        updated_item = {**current, **payload}
+        
+        # Ensure numeric fields are Decimal in the updated item
+        numeric_fields = ["taxes", "subtotal", "shipping", "discount", "totalAmount"]
+        for field in numeric_fields:
+            if field in updated_item:
+                updated_item[field] = to_decimal(updated_item[field])
+                
+        self.table.put_item(Item=updated_item)
+        return updated_item
+
+    def delete(self, order_id: str) -> bool:
+        self.table.delete_item(Key={"id": order_id})
+        return True

--- a/repositories/product_repo_ddb.py
+++ b/repositories/product_repo_ddb.py
@@ -1,0 +1,88 @@
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from typing import Any, Iterable
+
+from boto3.dynamodb.conditions import Attr
+
+from .ddb_session import product_table
+
+
+def _scan_all(table, **kwargs) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    start_key = None
+    while True:
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+        resp = table.scan(**kwargs)
+        items.extend(resp.get("Items", []))
+        start_key = resp.get("LastEvaluatedKey")
+        if not start_key:
+            break
+    return items
+
+
+def _convert_for_dynamodb(value: Any) -> Any:
+    """Recursively convert floats to Decimal for DynamoDB compatibility."""
+
+    if isinstance(value, float):
+        # DynamoDB does not accept float types; convert to Decimal preserving precision.
+        return Decimal(str(value))
+
+    if isinstance(value, Mapping):
+        return {k: _convert_for_dynamodb(v) for k, v in value.items()}
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_convert_for_dynamodb(v) for v in value]
+
+    return value
+
+
+class ProductRepo:
+    """DynamoDB-backed repository for product table."""
+
+    def __init__(self):
+        self._table = product_table()
+
+    def get(self, product_id: str) -> dict[str, Any] | None:
+        resp = self._table.get_item(Key={"id": product_id})
+        return resp.get("Item")
+
+    def list_all(self) -> Iterable[dict[str, Any]]:
+        return _scan_all(self._table)
+
+    def list_by_category(self, category: str) -> Iterable[dict[str, Any]]:
+        return _scan_all(
+            self._table,
+            FilterExpression=Attr("category").eq(category),
+        )
+
+    def put(self, item: dict[str, Any]) -> None:
+        self._table.put_item(Item=_convert_for_dynamodb(item))
+
+    def update(self, product_id: str, updates: dict[str, Any]) -> dict[str, Any] | None:
+        if not updates:
+            return self.get(product_id)
+
+        update_expr_parts = []
+        expr_attr_values: dict[str, Any] = {}
+        expr_attr_names: dict[str, str] = {}
+
+        for field, value in updates.items():
+            placeholder = f":{field}"
+            name_placeholder = f"#{field}"
+            update_expr_parts.append(f"{name_placeholder} = {placeholder}")
+            expr_attr_values[placeholder] = _convert_for_dynamodb(value)
+            expr_attr_names[name_placeholder] = field
+
+        update_expression = "SET " + ", ".join(update_expr_parts)
+        resp = self._table.update_item(
+            Key={"id": product_id},
+            UpdateExpression=update_expression,
+            ExpressionAttributeValues=expr_attr_values,
+            ExpressionAttributeNames=expr_attr_names,
+            ReturnValues="ALL_NEW",
+        )
+        return resp.get("Attributes")
+
+    def delete(self, product_id: str) -> None:
+        self._table.delete_item(Key={"id": product_id})

--- a/repositories/product_repo_ddb.py
+++ b/repositories/product_repo_ddb.py
@@ -1,88 +1,354 @@
-from collections.abc import Mapping, Sequence
 from decimal import Decimal
-from typing import Any, Iterable
+from typing import Any, Dict, List, Optional, Tuple
+from boto3.dynamodb.conditions import Key, Attr
+import uuid
+from datetime import datetime, timezone
 
-from boto3.dynamodb.conditions import Attr
+from repositories.ddb_session import product_table
 
-from .ddb_session import product_table
+# ---- helpers -------------------------------------------------
+
+def to_decimal(value: Any) -> Decimal:
+    """Convierte int/float/str/None a Decimal de forma segura."""
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+def _encode_pagination_key(key: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    return key or None
+
+def _neg(n: int | float | Decimal | None) -> Decimal:
+    return -to_decimal(n or 0)
+
+def _tokens_from_name(name: str) -> List[str]:
+    # tokens simples para GSI5 (puedes mejorarlo con normalización)
+    return [name.lower()] if name else []
+
+def _build_gsi_attrs(item: Dict[str, Any]) -> Dict[str, Any]:
+    # GSI1: categoría por created_at
+    category = item.get("category") or "_UNCAT"
+    created_at = item.get("created_at") or _now_iso()
+    # GSI2: featured por total_sold desc -> usamos neg_total_sold
+    neg_total_sold = _neg(item.get("total_sold", 0))
+    # GSI3: price
+    price = to_decimal(item.get("price", 0))
+    # GSI5: tag/name search (elegimos 1 PK múltiple con tags y tokens de name)
+    # Para simplificar: guardamos solo el último "TAG#<tag>" usado al escribir.
+    # Si quieres múltiples entradas por tag, requiere escribir N ítems secundarios (fuera de alcance aquí).
+    first_tag = (item.get("tags") or item.get("genders") or ["_NO_TAG"])[0]
+    gsi = {
+        "gsi1_pk": f"CAT#{category}",
+        "gsi1_sk": created_at,
+        "gsi2_pk": "FEATURED",
+        "gsi2_sk": neg_total_sold,
+        "gsi3_pk": "PRICE",
+        "gsi3_sk": price,
+        "gsi5_pk": f"TAG#{str(first_tag).lower()}",
+        "gsi5_sk": created_at,
+        "neg_total_sold": neg_total_sold,
+    }
+    return gsi
+
+def _choose_query_plan(query: Optional[str], filters: Dict[str, Any], sort_by: Optional[str]) -> Dict[str, Any]:
+    category = filters.get("category")
+    min_price = filters.get("min_price")
+    max_price = filters.get("max_price")
+
+    if sort_by == "featured":
+        return {
+            "index": "GSI2_Featured",
+            "key": Key("gsi2_pk").eq("FEATURED"),
+            "range": None,
+            "forward": False,
+        }
+
+    if sort_by == "newest":
+        if category:
+            return {
+                "index": "GSI1_CategoryNewest",
+                "key": Key("gsi1_pk").eq(f"CAT#{category}"),
+                "range": None,
+                "forward": False,
+            }
+        return {
+            "index": "GSI1_CategoryNewest",
+            "key": Key("gsi1_pk").eq("CAT#_ALL"),
+            "range": None,
+            "forward": False,
+        }
+
+    if sort_by in ("priceAsc", "priceDesc"):
+        base: Dict[str, Any] = {
+            "index": "GSI3_Price",
+            "key": Key("gsi3_pk").eq("PRICE"),
+            "range": None,
+        }
+        if min_price is not None and max_price is not None:
+            base["range"] = Key("gsi3_sk").between(
+                to_decimal(min_price),
+                to_decimal(max_price),
+            )
+        elif min_price is not None:
+            base["range"] = Key("gsi3_sk").gte(to_decimal(min_price))
+        elif max_price is not None:
+            base["range"] = Key("gsi3_sk").lte(to_decimal(max_price))
+
+        return {**base, "forward": (sort_by == "priceAsc")}
+
+    if query:
+        return {
+            "index": "GSI5_TagSearch",
+            "key": Key("gsi5_pk").eq(f"TAG#{query.lower()}"),
+            "range": None,
+            "forward": False,
+        }
+
+    if category:
+        return {
+            "index": "GSI1_CategoryNewest",
+            "key": Key("gsi1_pk").eq(f"CAT#{category}"),
+            "range": None,
+            "forward": False,
+        }
+
+    return {
+        "index": "GSI2_Featured",
+        "key": Key("gsi2_pk").eq("FEATURED"),
+        "range": None,
+        "forward": False,
+    }
 
 
-def _scan_all(table, **kwargs) -> list[dict[str, Any]]:
-    items: list[dict[str, Any]] = []
-    start_key = None
-    while True:
-        if start_key:
-            kwargs["ExclusiveStartKey"] = start_key
-        resp = table.scan(**kwargs)
-        items.extend(resp.get("Items", []))
-        start_key = resp.get("LastEvaluatedKey")
-        if not start_key:
-            break
-    return items
+def _map_out(item: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": item["id"],
+        "gender": item.get("genders", []),
+        "images": item.get("images", []),
+        "reviews": item.get("reviews", []),
+        "publish": item.get("publish", "published"),
+        "ratings": item.get("ratings_buckets", []),
+        "category": item["category"],
+        "available": int(item.get("available", 0)),
+        "price_sale": item.get("price_sale"),
+        "taxes": item.get("taxes"),
+        "quantity": int(item.get("quantity", 0)),
+        "inventory_type": item.get("inventory_type"),
+        "tags": item.get("tags", []),
+        "code": item.get("code"),
+        "description": item.get("description_html"),
+        "sku": item.get("sku"),
+        "created_at": item.get("created_at"),
+        "name": item["name"],
+        "price": float(item["price"]),
+        "cover_url": item.get("cover_url"),
+        "colors": item.get("colors", []),
+        "total_ratings": float(item.get("total_ratings", 0.0)),
+        "total_sold": int(item.get("total_sold", 0)),
+        "total_reviews": int(item.get("total_reviews", 0)),
+        "new_label": item.get("new_label", {"enabled": True, "content": "NEW"}),
+        "sale_label": {"enabled": bool(item.get("price_sale") is not None), "content": "SALE"},
+        "sizes": item.get("sizes", []),
+        "sub_description": item.get("sub_description"),
+    }
 
-
-def _convert_for_dynamodb(value: Any) -> Any:
-    """Recursively convert floats to Decimal for DynamoDB compatibility."""
-
-    if isinstance(value, float):
-        # DynamoDB does not accept float types; convert to Decimal preserving precision.
-        return Decimal(str(value))
-
-    if isinstance(value, Mapping):
-        return {k: _convert_for_dynamodb(v) for k, v in value.items()}
-
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return [_convert_for_dynamodb(v) for v in value]
-
-    return value
-
+# ---- repository ---------------------------------------------
 
 class ProductRepo:
-    """DynamoDB-backed repository for product table."""
-
     def __init__(self):
-        self._table = product_table()
+        self.table = product_table()
 
-    def get(self, product_id: str) -> dict[str, Any] | None:
-        resp = self._table.get_item(Key={"id": product_id})
+    # CREATE
+    def create(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        product_id = str(uuid.uuid4())
+        now = _now_iso()
+        taxes = payload.get("taxes")
+        price_sale = payload.get("price_sale")
+
+        item = {
+            "pk": f"PRODUCT#{product_id}",
+            "sk": "PRODUCT",
+            "id": product_id,
+            "created_at": now,
+            "name": payload["name"],
+            "category": payload["category"],
+            "price": to_decimal(payload["price"]),
+            "publish": payload.get("publish", "published"),
+            "available": int(payload.get("available", 0)),
+            "quantity": int(payload.get("quantity", 0)),
+            "taxes": to_decimal(taxes) if taxes is not None else None,
+            "price_sale": to_decimal(price_sale) if price_sale is not None else None,
+            "inventory_type": payload.get("inventory_type"),
+            "code": payload.get("code"),
+            "sku": payload.get("sku"),
+            "description_html": payload.get("description"),
+            "sub_description": payload.get("sub_description"),
+            "cover_url": payload.get("cover_url"),
+            "genders": payload.get("gender", []),
+            "tags": payload.get("tags", []),
+            "images": payload.get("images", []),
+            "colors": payload.get("colors", []),
+            "sizes": payload.get("sizes", []),
+            "ratings_buckets": [rb.model_dump(by_alias=False) if hasattr(rb, "model_dump") else rb for rb in payload.get("ratings", [])],
+            "reviews": [rv.model_dump(by_alias=False) if hasattr(rv, "model_dump") else rv for rv in payload.get("reviews", [])],
+            "total_ratings": to_decimal(payload.get("total_ratings", 0.0)),
+            "total_sold": int(payload.get("total_sold", 0)),
+            "total_reviews": int(payload.get("total_reviews", 0)),
+            "new_label": payload.get("new_label", {"enabled": True, "content": "NEW"}),
+        }
+        item.update(_build_gsi_attrs(item))
+        self.table.put_item(Item=item)
+        return item
+
+    # READ
+    def get_by_id(self, product_id: str) -> Optional[Dict[str, Any]]:
+        resp = self.table.get_item(Key={"pk": f"PRODUCT#{product_id}", "sk": "PRODUCT"})
         return resp.get("Item")
+    
+    # LIST ALL
+    def list_all(self) -> List[Dict[str, Any]]:
+        items = []
+        exclusive_key = None
+        while True:
+            kwargs = {"FilterExpression": Attr("sk").eq("PRODUCT")}
+            if exclusive_key:
+                kwargs["ExclusiveStartKey"] = exclusive_key
+            resp = self.table.scan(**kwargs)
+            items.extend(resp.get("Items", []))
+            exclusive_key = resp.get("LastEvaluatedKey")
+            if not exclusive_key:
+                break
+        return items
 
-    def list_all(self) -> Iterable[dict[str, Any]]:
-        return _scan_all(self._table)
+    # SEARCH/LIST
+    def search(
+        self,
+        query: Optional[str],
+        filters: Dict[str, Any],
+        sort_by: Optional[str],
+        limit: int,
+        next_token: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        plan = _choose_query_plan(query, filters, sort_by)
+        key_condition = plan["key"]
+        if plan.get("range") is not None:
+            key_condition = key_condition & plan["range"]
 
-    def list_by_category(self, category: str) -> Iterable[dict[str, Any]]:
-        return _scan_all(
-            self._table,
-            FilterExpression=Attr("category").eq(category),
+        kwargs = dict(
+            IndexName=plan["index"],
+            KeyConditionExpression=key_condition,
+            ScanIndexForward=plan.get("forward", False),
+            Limit=limit,
         )
 
-    def put(self, item: dict[str, Any]) -> None:
-        self._table.put_item(Item=_convert_for_dynamodb(item))
+        fe = None
+        if filters.get("genders"):
+            f = Attr("genders").contains(filters["genders"][0])
+            for g in filters["genders"][1:]:
+                f = f | Attr("genders").contains(g)
+            fe = f if fe is None else fe & f
 
-    def update(self, product_id: str, updates: dict[str, Any]) -> dict[str, Any] | None:
-        if not updates:
-            return self.get(product_id)
+        if filters.get("colors"):
+            f = Attr("colors").contains(filters["colors"][0])
+            for c in filters["colors"][1:]:
+                f = f | Attr("colors").contains(c)
+            fe = f if fe is None else fe & f
 
-        update_expr_parts = []
-        expr_attr_values: dict[str, Any] = {}
-        expr_attr_names: dict[str, str] = {}
+        if (mr := filters.get("min_rating")) is not None:
+            f = Attr("total_ratings").gte(to_decimal(mr))
+            fe = f if fe is None else fe & f
 
-        for field, value in updates.items():
-            placeholder = f":{field}"
-            name_placeholder = f"#{field}"
-            update_expr_parts.append(f"{name_placeholder} = {placeholder}")
-            expr_attr_values[placeholder] = _convert_for_dynamodb(value)
-            expr_attr_names[name_placeholder] = field
+        if fe is not None:
+            kwargs["FilterExpression"] = fe
+        if next_token:
+            kwargs["ExclusiveStartKey"] = next_token
 
-        update_expression = "SET " + ", ".join(update_expr_parts)
-        resp = self._table.update_item(
-            Key={"id": product_id},
-            UpdateExpression=update_expression,
-            ExpressionAttributeValues=expr_attr_values,
-            ExpressionAttributeNames=expr_attr_names,
+        resp = self.table.query(**kwargs)
+        return resp.get("Items", []), resp.get("LastEvaluatedKey")
+
+    # UPDATE (PUT parcial: solo campos presentes)
+    def update(self, product_id: str, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not payload:
+            return self.get_by_id(product_id)
+
+        # Map camel->snake atributos internos
+        mapping = {
+            "name": "name", "category": "category", "price": "price", "publish": "publish",
+            "available": "available", "quantity": "quantity", "taxes": "taxes",
+            "price_sale": "price_sale", "inventory_type": "inventory_type", "code": "code",
+            "sku": "sku", "description": "description_html", "sub_description": "sub_description",
+            "cover_url": "cover_url", "gender": "genders", "tags": "tags", "images": "images",
+            "colors": "colors", "sizes": "sizes", "ratings": "ratings_buckets", "reviews": "reviews",
+            "total_ratings": "total_ratings", "total_sold": "total_sold", "total_reviews": "total_reviews",
+        }
+
+        numeric_attrs = {
+            "price", "price_sale", "taxes", "available", "quantity", "total_ratings", "total_sold", 
+            "total_reviews", "gsi2_sk", "gsi3_sk", "neg_total_sold",
+        }
+
+        expr_set = []
+        names = {}
+        values = {}
+
+        for k_in, v in payload.items():
+            if v is None:
+                continue
+            if k_in in ("ratings", "reviews") and hasattr(v, "model_dump"):
+                v = v.model_dump(by_alias=False)
+
+            attr = mapping.get(k_in)
+            if not attr:
+                continue
+
+            # Si el atributo es numérico, lo convertimos a Decimal
+            if attr in numeric_attrs:
+                v = to_decimal(v)
+
+            names[f"#_{attr}"] = attr
+            values[f":{attr}"] = v
+            expr_set.append(f"#_{attr} = :{attr}")
+
+        # recomputar GSIs si cambian category/price/total_sold/tags/genders
+        if any(n in names for n in ["#_category", "#_price", "#_total_sold", "#_genders", "#_tags"]):
+            current = self.get_by_id(product_id) or {}
+
+            # Mezclamos el estado actual con los nuevos valores
+            merged: Dict[str, Any] = {
+                **current,
+                **{n.replace("#_", ""): values[f":{n.replace('#_', '')}"] for n in names},
+            }
+
+            gsi_attrs = _build_gsi_attrs(merged)  # gsi1_pk, gsi1_sk, gsi2_pk, gsi2_sk, gsi3_pk, gsi3_sk, ...
+
+            for gk, gv in gsi_attrs.items():
+                # Forzamos Decimal en atributos numéricos del GSI
+                if gk in numeric_attrs:
+                    gv = to_decimal(gv)
+
+                names[f"#_{gk}"] = gk
+                values[f":{gk}"] = gv
+                expr_set.append(f"#_{gk} = :{gk}")
+
+        if not expr_set:
+            return self.get_by_id(product_id)
+
+        update_expr = "SET " + ", ".join(expr_set)
+
+        resp = self.table.update_item(
+            Key={"pk": f"PRODUCT#{product_id}", "sk": "PRODUCT"},
+            UpdateExpression=update_expr,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
             ReturnValues="ALL_NEW",
         )
         return resp.get("Attributes")
 
-    def delete(self, product_id: str) -> None:
-        self._table.delete_item(Key={"id": product_id})
+    # DELETE
+    def delete(self, product_id: str) -> bool:
+        self.table.delete_item(Key={"pk": f"PRODUCT#{product_id}", "sk": "PRODUCT"})
+        return True

--- a/repositories/s3_adapter.py
+++ b/repositories/s3_adapter.py
@@ -81,3 +81,14 @@ class S3Adapter:
     ) -> dict[str, str]:
         key = self._kb.user_profile_photos(user_id, filename)
         return self._presign_put(key=key, content_type=content_type, expires_in=expires_in)
+    
+    def presign_product_image_put(
+        self,
+        *,
+        product_id: str,
+        filename: str,
+        content_type: str,
+        expires_in: int = 3600,
+    ) -> dict[str, str]:
+        key = self._kb.product_image(product_id, filename)
+        return self._presign_put(key=key, content_type=content_type, expires_in=expires_in)

--- a/repositories/s3_keys.py
+++ b/repositories/s3_keys.py
@@ -45,3 +45,10 @@ class KeyBuilder:
         {env}/users/{user_id}/profile_photos/{filename}
         """
         return join(self.user_root(user_id), "profile_photos", _clean(filename))
+    
+    def product_image(self, product_id: str, filename: str) -> str:
+        """
+        Full object key under the product images prefix, including filename.
+        {env}/products/{product_id}/{filename}
+        """
+        return join(self.env, "products", _clean(product_id), _clean(filename))

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1,0 +1,34 @@
+from typing import List, Optional, Dict, Any
+from repositories.order_repo_ddb import OrderRepo
+from api.schemas.orders import Order, OrderCreate, OrderUpdate
+
+class OrderService:
+    def __init__(self, repo: OrderRepo):
+        self.repo = repo
+
+    def list_orders(self) -> List[Order]:
+        items = self.repo.list_all()
+        return [Order(**item) for item in items]
+
+    def get_order(self, order_id: str) -> Optional[Order]:
+        item = self.repo.get_by_id(order_id)
+        if item:
+            return Order(**item)
+        return None
+
+    def create_order(self, payload: OrderCreate) -> Order:
+        # Convert Pydantic model to dict
+        data = payload.model_dump()
+        item = self.repo.create(data)
+        return Order(**item)
+
+    def update_order(self, order_id: str, payload: OrderUpdate) -> Optional[Order]:
+        # Convert Pydantic model to dict, excluding None values
+        data = payload.model_dump(exclude_unset=True)
+        item = self.repo.update(order_id, data)
+        if item:
+            return Order(**item)
+        return None
+
+    def delete_order(self, order_id: str) -> bool:
+        return self.repo.delete(order_id)

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -1,0 +1,69 @@
+from typing import Any
+from uuid import uuid4
+
+from api.schemas.products import PutProduct
+from repositories.product_repo_ddb import ProductRepo
+
+
+class ProductService:
+    def __init__(self, repo: ProductRepo):
+        self.repo = repo
+        self._excluded_fields = {"id"}
+
+    def list_products(
+        self,
+        *,
+        category: str | None = None,
+        inventory_type: str | None = None,
+        publish: str | None = None,
+    ) -> list[dict[str, Any]]:
+        items = list(self.repo.list_all())
+
+        def _matches_filters(product: dict[str, Any]) -> bool:
+            if category and product.get("category") != category:
+                return False
+            if inventory_type and product.get("inventory_type") != inventory_type:
+                return False
+            if publish and product.get("publish") != publish:
+                return False
+            return True
+
+        return [self._map_product(i) for i in items if _matches_filters(i)]
+
+    def get(self, product_id: str) -> dict[str, Any] | None:
+        item = self.repo.get(product_id)
+        if not item:
+            return None
+        return self._map_product(item)
+
+    def create(self, put_product: PutProduct) -> dict[str, Any]:
+        data = put_product.model_dump(exclude_unset=True, exclude_none=True)
+        product_id = data.get("id") or f"product_{uuid4().hex}"
+        data["id"] = product_id
+        self.repo.put(data)
+        created = self.repo.get(product_id)
+        if not created:
+            raise ValueError(f"Product {product_id} not found after creation")
+        return self._map_product(created)
+
+    def update(self, product_id: str, put_product: PutProduct) -> dict[str, Any] | None:
+        existing = self.repo.get(product_id)
+        if not existing:
+            return None
+        updates = put_product.model_dump(exclude_unset=True, exclude_none=True)
+        for field in self._excluded_fields:
+            updates.pop(field, None)
+        if not updates:
+            return self._map_product(existing)
+        self.repo.update(product_id, updates)
+        refreshed = self.repo.get(product_id)
+        if not refreshed:
+            raise ValueError(f"Product {product_id} not found after update")
+        return self._map_product(refreshed)
+
+    def delete(self, product_id: str) -> None:
+        self.repo.delete(product_id)
+
+    def _map_product(self, item: dict[str, Any]) -> dict[str, Any]:
+        product = PutProduct.model_validate(item)
+        return product.model_dump(by_alias=True, exclude_none=True)

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -1,69 +1,134 @@
-from typing import Any
-from uuid import uuid4
-
-from api.schemas.products import PutProduct
+from typing import Dict, Any, Optional
+from api.schemas.products import ProductOut, ProductCreate, ProductUpdate, Review, RatingBucket, Label
 from repositories.product_repo_ddb import ProductRepo
-
+from repositories.s3_adapter import S3Adapter
+from api.schemas.files import FileSpec
 
 class ProductService:
-    def __init__(self, repo: ProductRepo):
+    def __init__(self, repo: ProductRepo, s3: S3Adapter):
         self.repo = repo
-        self._excluded_fields = {"id"}
+        self.s3 = s3
 
-    def list_products(
-        self,
-        *,
-        category: str | None = None,
-        inventory_type: str | None = None,
-        publish: str | None = None,
-    ) -> list[dict[str, Any]]:
-        items = list(self.repo.list_all())
+    def create_product(self, data: ProductCreate) -> ProductOut:
+        raw = self.repo.create(data.model_dump(by_alias=False))
+        return self._map_product(raw)
+    
+    def list_products(self) -> list[ProductOut]:
+        items = self.repo.list_all()
+        return [self._map_product(it) for it in items]
 
-        def _matches_filters(product: dict[str, Any]) -> bool:
-            if category and product.get("category") != category:
-                return False
-            if inventory_type and product.get("inventory_type") != inventory_type:
-                return False
-            if publish and product.get("publish") != publish:
-                return False
-            return True
+    def get_product(self, product_id: str, get_presigned_url: bool = True) -> Optional[ProductOut]:
+        raw = self.repo.get_by_id(product_id)
+        return self._map_product(raw, get_presigned_url) if raw else None
 
-        return [self._map_product(i) for i in items if _matches_filters(i)]
+    def search_products(self, query: str | None, filters: dict, sort_by: str | None, limit: int, next_token: dict | None):
+        items, token = self.repo.search(query, filters, sort_by, limit, next_token)
+        mapped = [self._map_product(it) for it in items]
+        return {"results": mapped, "limit": limit, "nextToken": token}
 
-    def get(self, product_id: str) -> dict[str, Any] | None:
-        item = self.repo.get(product_id)
-        if not item:
-            return None
-        return self._map_product(item)
+    def update_product(self, product_id: str, data: ProductUpdate) -> Optional[ProductOut]:
+        update_data = data.model_dump(exclude_none=True, by_alias=False)
+        # Exclude images from update - use add_images endpoint instead
+        update_data.pop("images", None)
+        raw = self.repo.update(product_id, update_data)
+        return self._map_product(raw) if raw else None
 
-    def create(self, put_product: PutProduct) -> dict[str, Any]:
-        data = put_product.model_dump(exclude_unset=True, exclude_none=True)
-        product_id = data.get("id") or f"product_{uuid4().hex}"
-        data["id"] = product_id
-        self.repo.put(data)
-        created = self.repo.get(product_id)
-        if not created:
-            raise ValueError(f"Product {product_id} not found after creation")
-        return self._map_product(created)
-
-    def update(self, product_id: str, put_product: PutProduct) -> dict[str, Any] | None:
-        existing = self.repo.get(product_id)
+    def delete_product(self, product_id: str) -> bool:
+        return self.repo.delete(product_id)
+    
+    def generate_put_presigned_urls(self, product_id: str, files: list[FileSpec]) -> dict[str, dict[str, str]]:
+        """Generate presigned URLs for uploading product images to S3"""
+        presigned_urls = {}
+        product = self.get_product(product_id)
+        if not product:
+            raise ValueError(f"Product {product_id} not found")
+        
+        for file in files:
+            if not isinstance(file, FileSpec):
+                raise TypeError("Each file must be a FileSpec instance.")
+            
+            file_name = file.file_name
+            file_content_type = file.content_type
+            if not file_name or not file_content_type:
+                raise ValueError("File 'file_name' and 'content_type' cannot be empty.")
+            
+            result = self.s3.presign_product_image_put(
+                product_id=product_id,
+                filename=file_name,
+                content_type=file_content_type
+            )
+            presigned_urls[file_name] = result["url"]
+        return presigned_urls
+    
+    def add_images(self, product_id: str, file_names: list[str]) -> list[str]:
+        """Add image keys to product after successful upload"""
+        # Get product without URL conversion to work with raw S3 keys
+        existing = self.get_product(product_id, get_presigned_url=False)
         if not existing:
-            return None
-        updates = put_product.model_dump(exclude_unset=True, exclude_none=True)
-        for field in self._excluded_fields:
-            updates.pop(field, None)
-        if not updates:
-            return self._map_product(existing)
-        self.repo.update(product_id, updates)
-        refreshed = self.repo.get(product_id)
-        if not refreshed:
-            raise ValueError(f"Product {product_id} not found after update")
-        return self._map_product(refreshed)
+            raise ValueError(f"Product {product_id} not found")
+        
+        images = []
+        for file_name in file_names:
+            key = self.s3._kb.product_image(product_id, file_name)
+            images.append(key)
+        
+        # Get current images and append new ones (working with raw keys)
+        current_images = existing.images if existing.images else []
+        updated_images = current_images + images
+        
+        self.repo.update(
+            product_id,
+            {"images": updated_images}
+        )
+        return images
+    
+    def _map_product(self, item: Dict[str, Any], get_presigned_url: bool = True) -> ProductOut:
+        """Map raw product data to ProductOut schema with optional S3 URL conversion"""
+        reviews = sorted(item.get("reviews", []), key=lambda r: r.get("posted_at", ""), reverse=True)
+        ratings = item.get("ratings", item.get("ratings_buckets", []))
+        new_label = item.get("new_label") or {"enabled": True, "content": "NEW"}
+        sale_label = {"enabled": item.get("price_sale") is not None, "content": "SALE"}
+        
+        # Convert S3 keys to public URLs if requested
+        images = item.get("images", [])
+        if get_presigned_url and images:
+            images = [self.s3.get_s3_public_url(key=image) for image in images]
+        
+        # Set cover_url to first image if null
+        cover_url = item.get("cover_url")
+        if not cover_url and images:
+            cover_url = images[0]
 
-    def delete(self, product_id: str) -> None:
-        self.repo.delete(product_id)
+        return ProductOut(
+            id=item["id"],
+            gender=item.get("gender") or item.get("genders", []),
+            images=images,
+            reviews=[Review(**r) for r in reviews],
+            publish=item.get("publish", "published"),
+            ratings=[RatingBucket(**b) for b in ratings],
+            category=item["category"],
+            available=item.get("available", 0),
+            price_sale=item.get("price_sale"),
+            taxes=item.get("taxes"),
+            quantity=item.get("quantity", 0),
+            inventory_type=item.get("inventory_type"),
+            tags=item.get("tags", []),
+            code=item.get("code"),
+            description=item.get("description_html"),
+            sku=item.get("sku"),
+            created_at=item["created_at"],
+            name=item["name"],
+            price=float(item["price"]),
+            cover_url=cover_url,
+            colors=item.get("colors", []),
+            total_ratings=float(item.get("total_ratings", 0.0)),
+            total_sold=int(item.get("total_sold", 0)),
+            total_reviews=int(item.get("total_reviews", 0)),
+            new_label=Label(**new_label),
+            sale_label=Label(**sale_label),
+            sizes=item.get("sizes", []),
+            sub_description=item.get("sub_description"),
+        )
 
-    def _map_product(self, item: dict[str, Any]) -> dict[str, Any]:
-        product = PutProduct.model_validate(item)
-        return product.model_dump(by_alias=True, exclude_none=True)
+
+


### PR DESCRIPTION
## Summary
- recursively coerce product payload floats to Decimal before storing them in DynamoDB
- ensure update expressions serialize numeric updates with the same DynamoDB-safe conversion

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_6908e8297d288327aba7d3f273c403f0