### PR TITLE
Make season field optional in CreateTournament schema

### DIFF
--- a/api/schemas/tournaments.py
+++ b/api/schemas/tournaments.py
@@ -66,7 +66,7 @@ class TournamentRules(BaseModel):
 
 class CreateTournament(BaseModel):
     name: str
-    season: str
+    season: str | None = None
     type: TournamentType
     rules: TournamentRules | None = None
 


### PR DESCRIPTION
The season field was required, causing 422 ValidationError when clients created tournaments without specifying a season. This change makes the field optional with a default value of None.

Fixes: ValidationError 422 when season is not provided

Slack thread: https://sportsmanagement-hq.slack.com/archives/C09PZ3DD3DX/p1772552844709059

https://claude.ai/code/session_01FbaiFmpJZHnTFXsCGhDySQ